### PR TITLE
pm/add s3 public access block for bastion bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,16 @@ resource "aws_s3_bucket" "bucket" {
   tags = merge(var.tags)
 }
 
+resource "aws_s3_bucket_public_access_block" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+
 resource "aws_s3_bucket_object" "bucket_public_keys_readme" {
   bucket  = aws_s3_bucket.bucket.id
   key     = "public-keys/README.txt"


### PR DESCRIPTION
**PR Description**
Add S3 public access block at the bucket level. To prevent accidental exposure of the object in this bucket.

**Documentation**
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block
